### PR TITLE
Remove use of prototype extension

### DIFF
--- a/addon/components/md-text.js
+++ b/addon/components/md-text.js
@@ -2,13 +2,15 @@ import Ember from 'ember';
 import Remarkable from 'remarkable';
 import hljs from 'hljs';
 
+const { computed } = Ember;
+
 export default Ember.Component.extend({
   text: '',
   typographer: false,
   linkify: false,
   html: false,
 
-  parsedMarkdown: function() {
+  parsedMarkdown: computed('text', 'html', 'typographer', 'linkify', function() {
     var md = new Remarkable({
       typographer: this.get('typographer'),
       linkify: this.get('linkify'),
@@ -31,5 +33,5 @@ export default Ember.Component.extend({
 
     var html = md.render(this.get('text'));
     return new Ember.Handlebars.SafeString(html);
-  }.property('text', 'highlight', 'typographer', 'linkify')
+  })
 });


### PR DESCRIPTION
This makes the component compatible with newer versions of Ember.