### PR TITLE
Remove `ember-template-compiler` from dependencies.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-remarkable",
   "dependencies": {
-    "ember": "~2.4.3",
+    "ember": "~2.5.0",
     "ember-cli-shims": "0.1.1",
     "ember-cli-test-loader": "0.2.2",
     "ember-qunit-notifications": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
     "ember-ajax": "0.7.1",
-    "ember-cli": "2.4.3",
+    "ember-cli": "^2.5.1",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars": "^1.0.3",
@@ -47,8 +47,7 @@
     "hljs"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6",
-    "ember-template-compiler": "^1.8.0"
+    "ember-cli-babel": "^5.1.6"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
It turns out, it's unnecessary.