### PR TITLE
Replace deprecated Ember.Handlebars.SafeString with Ember.String.html…

### DIFF
--- a/addon/components/md-text.js
+++ b/addon/components/md-text.js
@@ -63,7 +63,7 @@ export default Ember.Component.extend({
 
   parsedMarkdown: computed('parsedMarkdownUnsafe', function () {
     const parsedMarkdownUnsafe = this.get('parsedMarkdownUnsafe');
-    return new Ember.Handlebars.SafeString(parsedMarkdownUnsafe);
+    return new Ember.String.htmlSafe(parsedMarkdownUnsafe);
   }),
 
   precompiledTemplate: computed('parsedMarkdownUnsafe', function () {


### PR DESCRIPTION
…Safe as specified in http://emberjs.com/deprecations/v2.x#toc_use-ember-string-htmlsafe-over-ember-handlebars-safestring