### PR TITLE
Feature: Exclude Highlight.js

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,6 +1,7 @@
 {
   "predef": [
     "document",
+    "hljs",
     "window",
     "-Promise"
   ],

--- a/README.md
+++ b/README.md
@@ -78,7 +78,29 @@ This addon uses [highlight.js](http://highlightjs.org) for syntax highlighting, 
 you just need to use Github style [code-fencing](https://help.github.com/articles/github-flavored-markdown/).
 Currently, only the component supports syntax highlighting.
 
+##### Excluding Highlightjs
 
+The use of highlight.js can be disabled by adding the following option to your `config/environment.js`:
+
+    remarkable: {
+       excludeHighlightJs: true
+    }
+    
+Highlightjs will no longer be included in your build.
+
+##### Custom Highlighting
+
+The highlight function, as used by remarkable, can easily be overriden. To do this, create your own `md-text` component:
+
+```js
+import MDTextComponent from 'ember-remarkable/components/md-text';
+
+export default MDTextComponent.extend({ 
+  highlight: function(str, lang) {
+     return '';
+  }
+}); 
+```
 
 #### Plugins
 

--- a/addon/components/md-text.js
+++ b/addon/components/md-text.js
@@ -41,7 +41,7 @@ export default Ember.Component.extend({
       }
 
       return '';
-    }
+    };
   }),
 
   parsedMarkdownUnsafe: computed('text', 'html', 'typographer', 'linkify', function () {

--- a/addon/components/md-text.js
+++ b/addon/components/md-text.js
@@ -16,7 +16,13 @@ export default Ember.Component.extend({
   extensions: true,
   dynamic: false,
   highlightJsExcluded: Ember.computed(function () {
-    let config = Ember.getOwner(this).resolveRegistration('config:environment');
+    let config;
+    if (Ember.getOwner) {
+      config = Ember.getOwner(this).resolveRegistration('config:environment');
+    }else{
+      let registry = this.container.registry || this.container._registry;
+      config = registry.resolve('config:environment');
+    }
     return config.remarkable.excludeHighlightJs || false;
   }),
   highlight: Ember.computed('highlightJsExcluded', function() {

--- a/index.js
+++ b/index.js
@@ -41,12 +41,6 @@ module.exports = {
       type: 'vendor',
       exports: { 'remarkable': ['default'] }
     });
-    if (!excludeHighlightJs) {
-      importContext.import('vendor/ember-remarkable/highlightjs-shim.js', {
-        type: 'vendor',
-        exports: { 'hljs': ['default'] }
-      });
-    }
   },
 
   // included from https://git.io/v6F7n

--- a/index.js
+++ b/index.js
@@ -9,6 +9,14 @@ module.exports = {
     return path.join(__dirname, 'blueprints');
   },
 
+  config: function(/*environment, appConfig*/) {
+    return {
+      remarkable: {
+        excludeHighlightJs: false
+      }
+    }
+  },
+
   included: function(app) {
     this._super.included.apply(this, arguments);
 
@@ -21,16 +29,24 @@ module.exports = {
       importContext = this._findHostForLegacyEmberCLI();
     }
 
+    var env = app.env;
+    var config = this.project.config(env || 'development');
+    var excludeHighlightJs = config.remarkable.excludeHighlightJs;
+
     importContext.import(bowerDirectory + '/remarkable/dist/remarkable.js');
-    importContext.import(bowerDirectory + '/highlightjs/highlight.pack.js');
+    if (!excludeHighlightJs) {
+      importContext.import(bowerDirectory + '/highlightjs/highlight.pack.js');
+    }
     importContext.import('vendor/ember-remarkable/shim.js', {
       type: 'vendor',
       exports: { 'remarkable': ['default'] }
     });
-    importContext.import('vendor/ember-remarkable/highlightjs-shim.js', {
-      type: 'vendor',
-      exports: { 'hljs': ['default'] }
-    });
+    if (!excludeHighlightJs) {
+      importContext.import('vendor/ember-remarkable/highlightjs-shim.js', {
+        type: 'vendor',
+        exports: { 'hljs': ['default'] }
+      });
+    }
   },
 
   // included from https://git.io/v6F7n

--- a/tests/integration/components/md-text-test.js
+++ b/tests/integration/components/md-text-test.js
@@ -48,6 +48,15 @@ test('it renders text without highlights', function(assert) {
   assert.equal(this.$().find('.hljs-keyword').length, 0);
 });
 
+test('it renders text with highlights when highlight.js is not excluded', function(assert) {
+  this.render(hbs`{{md-text text='\`\`\`js\nvar awesome = require("awesome");\`\`\`'}}`);
+  assert.ok(this.$().find('.hljs-keyword').length > 0);
+});
+
+test('it renders text without highlights when highlight.js is excluded', function(assert) {
+  this.render(hbs`{{md-text highlightJsExcluded=true text='\`\`\`js\nvar awesome = require("awesome");\`\`\`'}}`);
+  assert.equal(this.$().find('.hljs-keyword').length, 0);
+});
 
 test('it renders a dynamic template', function(assert) {
   this.tpl = "{{link-to 'root' 'Foo'}} <a href>Bar</a>";

--- a/tests/integration/components/md-text-test.js
+++ b/tests/integration/components/md-text-test.js
@@ -30,10 +30,17 @@ test('it renders html when the html option is set to true', function(assert) {
   assert.equal(this.$().find('abbr').length, 1);
 });
 
-
 test('it renders with syntax highlighting when a language is specified', function(assert) {
   this.render(hbs`{{md-text text='# Markdown is fun\n \`\`\`js\nvar awesome = require("awesome");\`\`\`'}}`);
   assert.ok(this.$().find('.language-js').length);
+});
+
+test('it allows to override the highlight function', function(assert) {
+  this.set('highlight', function(str){
+    return `<h1>${str}</h1>`;
+  });
+  this.render(hbs`{{md-text highlight=highlight text='\`\`\`text\nCustom highlighting\n\`\`\`'}}`);
+  assert.ok(this.$().find('code').find('h1').length);
 });
 
 test('it renders text without highlights', function(assert) {
@@ -79,7 +86,7 @@ test('it renders a video with plugin', function(assert) {
 
         return true;
       }, options);
-      
+
       md.renderer.rules.video = function (tokens, idx/*, options, env*/) {
         return `<iframe width="560" height="315" src="${tokens[idx].src}" frameborder="0"></iframe>`;
       };

--- a/vendor/ember-remarkable/highlightjs-shim.js
+++ b/vendor/ember-remarkable/highlightjs-shim.js
@@ -1,9 +1,0 @@
-/* globals hljs */
-
-define('hljs', [], function() {
-  'use strict';
-
-  return {
-    'default': hljs
-  };
-});


### PR DESCRIPTION
This PR allows to disable/exclude [highlight.js](http://highlightjs.org) using a configuration option in `config/environment.js`:

    remarkable: {
       excludeHighlightJs: true
    }

When HighlightJs is excluded, the component falls back to the default highlighting, and the dependency is no longer included in the `vendor.js` file. This fixes #30.

As an additional benefit, this PR allows to easily override the `highlight(str, lang)` function used by remarkable.