### PR TITLE
Tolerate absence of remarkable config

### DIFF
--- a/addon/components/md-text.js
+++ b/addon/components/md-text.js
@@ -24,7 +24,8 @@ export default Ember.Component.extend({
       let registry = this.container.registry || this.container._registry;
       config = registry.resolve('config:environment');
     }
-    return config.remarkable.excludeHighlightJs || false;
+    let remarkableConfig = config.remarkable || {};
+    return remarkableConfig.excludeHighlightJs || false;
   }),
   highlight: Ember.computed('highlightJsExcluded', function() {
     let highlightJsExcluded = this.get('highlightJsExcluded');

--- a/index.js
+++ b/index.js
@@ -31,7 +31,8 @@ module.exports = {
 
     var env = app.env;
     var config = this.project.config(env || 'development');
-    var excludeHighlightJs = config.remarkable.excludeHighlightJs;
+    var remarkableConfig = config.remarkable || {}
+    var excludeHighlightJs = remarkableConfig.excludeHighlightJs;
 
     importContext.import(bowerDirectory + '/remarkable/dist/remarkable.js');
     if (!excludeHighlightJs) {


### PR DESCRIPTION
In the process of upgrading ember-freestyle to the latest ember-remarkable, I noticed the following error if the remarkable config was absent:

```js
ember.debug.js:19829 TypeError: Cannot read property 'excludeHighlightJs' of undefined
    at Class.<anonymous> (md-text.js:24)
    at ComputedPropertyPrototype.get (ember.debug.js:19337)
    at Object.get (ember.debug.js:24154)
    at Class.get (ember.debug.js:37057)
    at Class.<anonymous> (md-text.js:27)
    at ComputedPropertyPrototype.get (ember.debug.js:19337)
    at Object.get (ember.debug.js:24154)
    at Class.get (ember.debug.js:37057)
    at Class._super (md-text.js:55)
    at Class.<anonymous> (freestyle-md-text.js:10)
```

I figure it's desirable to tolerate the absence of the config object, hence this PR. It seems like the existing coverage is adequate, but let me know if you want any different tests, clarification, etc.

Cheers!

<details>
<summary>App using an addon using an addon...</summary>
This problem was present in a test app I have set up that consumes ember-freestyle. I don't want to make ember-freestyle users include a `remarkable: {}` config object in their environment.js. 

Also, as far as I can tell, it's not possible for them to exclude highlight.js in this addon within an addon scenario. So I don't want folks to get their hopes up just yet. I'm working on a separate solution to make highlight.js optional in ember-freestyle, so things should work out one way or another.
</details>